### PR TITLE
Implement git init in write_devcontainer

### DIFF
--- a/codex-script.sh
+++ b/codex-script.sh
@@ -229,6 +229,15 @@ write_devcontainer() {
     }' > "$DEST_DIR/.devcontainer/devcontainer.json"
 
   echo "✅ .devcontainer/devcontainer.json created at $DEST_DIR/.devcontainer/devcontainer.json"
+
+  if command -v git >/dev/null && [[ ! -d "$DEST_DIR/.git" ]]; then
+    (
+      cd "$DEST_DIR"
+      git init -b main
+      git add .
+      git commit -m "Initial commit"
+    )
+  fi
 }
 
 # --- Main Execution ---


### PR DESCRIPTION
## Summary
- call git after writing devcontainer files if git is available and repository not initialized

## Testing
- `bash -n codex-script.sh`


------
https://chatgpt.com/codex/tasks/task_e_684f235dd9a48327b1d3066fde29cb81