### PR TITLE
Refactor local command assignments

### DIFF
--- a/codex-script.sh
+++ b/codex-script.sh
@@ -264,8 +264,10 @@ resolve_all_dependencies() {
 configure_feature() {
   local key="$1"
   local path="${FEATURE_PATHS[$key]}"
-  local version=$(jq -r '.version // "latest"' "$path/devcontainer-feature.json")
-  local options_json=$(jq -c '.options // {}' "$path/devcontainer-feature.json")
+  local version
+  version=$(jq -r '.version // "latest"' "$path/devcontainer-feature.json")
+  local options_json
+  options_json=$(jq -c '.options // {}' "$path/devcontainer-feature.json")
   declare -A selected_opts
 
   if [[ "$options_json" != "{}" ]]; then

--- a/discover-github-feature3.sh
+++ b/discover-github-feature3.sh
@@ -73,10 +73,13 @@ select_features() {
 configure_feature() {
     local key="$1"
     local path="${FEATURE_PATHS[$key]}"
-    local id="$(basename "$path")"
+    local id
+    id="$(basename "$path")"
     local origin="${FEATURE_ORIGINS[$key]}"
-    local version=$(jq -r '.version // "latest"' "$path/devcontainer-feature.json")
-    local options_json=$(jq -c '.options' "$path/devcontainer-feature.json")
+    local version
+    version=$(jq -r '.version // "latest"' "$path/devcontainer-feature.json")
+    local options_json
+    options_json=$(jq -c '.options' "$path/devcontainer-feature.json")
     local -A selected_opts
 
     echo "⚙️ Configuring: $key"


### PR DESCRIPTION
## Summary
- refactor local variable assignments to split variable declaration from command substitution

## Testing
- `bash -n codex-script.sh discover-github-feature3.sh`


------
https://chatgpt.com/codex/tasks/task_e_684fa1f6f91083278ee5c7a94fa47a76