### PR TITLE
Fix boolean option handling in configure_feature

### DIFF
--- a/codex-script.sh
+++ b/codex-script.sh
@@ -304,7 +304,11 @@ configure_feature() {
 
   local opts="{}"
   for k in "${!selected_opts[@]}"; do
-    opts=$(echo "$opts" | jq --arg k "$k" --arg v "${selected_opts[$k]}" '. + {($k): $v}')
+    if [[ ${selected_opts[$k]} =~ ^(true|false)$ ]]; then
+      opts=$(echo "$opts" | jq --arg k "$k" --argjson v "${selected_opts[$k]}" '. + {($k): $v}')
+    else
+      opts=$(echo "$opts" | jq --arg k "$k" --arg v "${selected_opts[$k]}" '. + {($k): $v}')
+    fi
   done
   FEATURE_OPTS["$key"]="$opts"
   FEATURE_VERSIONS["$key"]="$version"


### PR DESCRIPTION
## Summary
- correctly handle boolean values when building the options JSON in `configure_feature`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68500ee1d2388327a401710700b8c723