### PR TITLE
Add curl to dependency checks

### DIFF
--- a/codex-script.sh
+++ b/codex-script.sh
@@ -19,6 +19,7 @@ check_dependencies() {
   command -v dialog >/dev/null || missing+=("dialog")
   command -v jq >/dev/null || missing+=("jq")
   command -v git >/dev/null || missing+=("git")
+  command -v curl >/dev/null || missing+=("curl")
 
   if [[ ${#missing[@]} -gt 0 ]]; then
     if dialog --yesno "Missing required dependencies:\n${missing[*]}\n\nAttempt to install them now?" 10 60; then


### PR DESCRIPTION
## Summary
- check for `curl` in `check_dependencies`

## Testing
- `bash -n codex-script.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850156d6d988327b81fdea814ccb365