### PR TITLE
Update cleanup trap signals

### DIFF
--- a/codex-script.sh
+++ b/codex-script.sh
@@ -11,7 +11,8 @@ cleanup() {
   rm -f "$DIALOG_TEMP"
   rm -rf "$WORKDIR"
 }
-trap cleanup EXIT
+# Run cleanup when the script exits normally (EXIT), is interrupted (INT), or terminated (TERM)
+trap cleanup EXIT INT TERM
 
 # ---Script Dependency Check ---
 check_dependencies() {


### PR DESCRIPTION
## Summary
- trigger `cleanup` on EXIT, INT, and TERM
- explain the new trap behavior in comments

## Testing
- `bash -n codex-script.sh`
- `bash -n devcontainer-compose.sh`


------
https://chatgpt.com/codex/tasks/task_e_68501634ae6c8327a68dd9d27b6b02b9